### PR TITLE
Breaking change: No longer use `converted_to_xlsx_if_necessary` inside `safe_load_workbook`.

### DIFF
--- a/aa_py_openpyxl_util/_context.py
+++ b/aa_py_openpyxl_util/_context.py
@@ -5,7 +5,6 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Generator, Dict
 
-from aa_py_xl_convert import converted_to_xlsx_if_necessary
 from openpyxl import load_workbook
 from openpyxl.workbook import Workbook
 
@@ -33,16 +32,15 @@ def safe_load_workbook(
     Yields:
         The workbook.
     """
-    with converted_to_xlsx_if_necessary(path) as xlsx_path:
-        book: Workbook = load_workbook(
-            filename=xlsx_path,
-            read_only=read_only,
-            data_only=data_only,
-        )
-        try:
-            yield book
-        finally:
-            book.close()
+    book: Workbook = load_workbook(
+        filename=path,
+        read_only=read_only,
+        data_only=data_only,
+    )
+    try:
+        yield book
+    finally:
+        book.close()
 
 
 @contextmanager

--- a/ci-constraints.txt
+++ b/ci-constraints.txt
@@ -7,4 +7,3 @@ openpyxl==3.1.2
 pydicti==1.2.1
 
 # Private packages
-aa_py_xl_convert==1.0.3

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setuptools.setup(
     ],
     install_requires=[
         "openpyxl>=3.1.2,==3.1.*",  # openpyxl does not use semantic versioning.
-        "aa_py_xl_convert>=1.0.3,==1.*",
         "pydicti>=1.2.1,==1.*",
     ],
     package_data={


### PR DESCRIPTION
The caller of `safe_load_workbook` can still wrap it in `converted_to_xlsx_if_necessary` themselves when necessary (or in another, similar context manager). This puts the caller in control of how the conversion is handled, if at all.