### PR TITLE
Allow skipping rows in `define_named_ranges_for_dict_table` by making some keys `None`.

### DIFF
--- a/aa_py_openpyxl_util/_named_ranges.py
+++ b/aa_py_openpyxl_util/_named_ranges.py
@@ -13,7 +13,7 @@ def define_named_ranges_for_dict_table(
     sheet_name: str,
     first_table_row: int,
     first_table_col: int,
-    keys: Sequence[str],
+    keys: Sequence[str | None],
     workbook_scope: bool,
 ) -> None:
     """
@@ -25,13 +25,18 @@ def define_named_ranges_for_dict_table(
         sheet_name: The sheet on which the dict table exists.
         first_table_row: The number of the top row of the table.
         first_table_col: The number of the left-most column of the table (1=A)
-        keys: The dictionary keys, in the same order as in the first table column.
+        keys:
+            The dictionary keys, in the same order as in the first table column.
+            If a key is None, the corresponding row will be skipped, i.e., no named range will be defined for it.
         workbook_scope: Whether to make a workbook-scoped named range (True) or a sheet-scoped named range (False).
     """
     # Values are in the second table column
     col = first_table_col + 1
 
     for i, key in enumerate(keys):
+        if key is None:
+            continue
+
         row = first_table_row + 1 + i
         col_letter = get_column_letter(col)
         name = DefinedName(

--- a/test/named_ranges/test_define_named_ranges_for_dict_table.py
+++ b/test/named_ranges/test_define_named_ranges_for_dict_table.py
@@ -1,0 +1,72 @@
+import unittest
+
+from openpyxl import Workbook
+
+from aa_py_openpyxl_util import define_named_ranges_for_dict_table
+
+
+class TestDefineNamedRangesForDictTable(unittest.TestCase):
+    def test_define_named_ranges(self) -> None:
+        book = Workbook()
+        sheet = book.active
+        sheet.title = "Sheet1"
+        keys = ["key1", "key2", "key3"]
+
+        define_named_ranges_for_dict_table(
+            book=book,
+            sheet_name="Sheet1",
+            first_table_row=1,
+            first_table_col=1,
+            keys=keys,
+            workbook_scope=True,
+        )
+
+        for i, key in enumerate(keys):
+            defined_name = book.defined_names[key]
+            self.assertIsNotNone(defined_name)
+            self.assertEqual(
+                defined_name.attr_text,
+                f"'Sheet1'!$B${i+2}:$B${i+2}",
+            )
+
+    def test_skip_none_keys(self) -> None:
+        book = Workbook()
+        sheet = book.active
+        sheet.title = "Sheet1"
+        keys = ["key1", None, "key3"]
+
+        define_named_ranges_for_dict_table(
+            book=book,
+            sheet_name="Sheet1",
+            first_table_row=1,
+            first_table_col=1,
+            keys=keys,
+            workbook_scope=True,
+        )
+
+        self.assertEqual(book.defined_names["key1"].attr_text, "'Sheet1'!$B$2:$B$2")
+        self.assertIsNone(book.defined_names.get("key2"))
+        self.assertEqual(book.defined_names["key3"].attr_text, "'Sheet1'!$B$4:$B$4")
+
+    def test_sheet_scope_named_ranges(self) -> None:
+        book = Workbook()
+        sheet = book.active
+        sheet.title = "Sheet1"
+        keys = ["key1", "key2", "key3"]
+
+        define_named_ranges_for_dict_table(
+            book=book,
+            sheet_name="Sheet1",
+            first_table_row=1,
+            first_table_col=1,
+            keys=keys,
+            workbook_scope=False,
+        )
+
+        for i, key in enumerate(keys):
+            defined_name = sheet.defined_names[key]
+            self.assertIsNotNone(defined_name)
+            self.assertEqual(
+                defined_name.attr_text,
+                f"'Sheet1'!$B${i+2}:$B${i+2}",
+            )


### PR DESCRIPTION
This is required for better handling of run control options in output workbooks.