### PR TITLE
Add new optional argument `ci` to `find_table`, `read_table` and `read_dict_table` to make table lookups case-insensitive.

### DIFF
--- a/aa_py_openpyxl_util/_extract.py
+++ b/aa_py_openpyxl_util/_extract.py
@@ -4,7 +4,7 @@ import re
 from collections import OrderedDict
 from itertools import chain
 from logging import getLogger
-from typing import Generator, Optional, List, Any, Tuple, Dict, TYPE_CHECKING
+from typing import Generator, Optional, List, Any, Tuple, Dict, TYPE_CHECKING, Literal
 
 from ._data_util import data_to_dicts, skip_empty_rows
 from ._find_table import find_table
@@ -23,8 +23,28 @@ def read_table(
     book: "Workbook",
     table_name: str,
     columns: List[str] | None = None,
+    ci: (
+        bool | Literal["warn"]
+    ) = False,  # TODO: Make this required in the next major version.
 ) -> Generator[Dict[str, Any], None, None]:
-    sheet, table_range = find_table(book=book, name=table_name)
+    """
+    Read a table from a workbook and yield its rows as dictionaries.
+
+    Args:
+        book: The workbook, opened using openpyxl, from which to read the table.
+        table_name: The name of the table (ListObject or named range) to read.
+        columns:
+            Optional list of column names to extract.
+            If not given, all columns are extracted.
+        ci:
+            Whether the table name lookup should be case-insensitive.
+            When this is "warn", a warning is logged when the provided case does not match the actual case.
+
+    Returns:
+        A generator of dictionaries mapping column names to cell values for
+        each non-header row in the table.
+    """
+    sheet, table_range = find_table(book=book, name=table_name, ci=ci)
     return data_to_dicts(
         data=sheet[table_range],
         columns=columns,
@@ -37,11 +57,33 @@ def read_dict_table(
     *,
     book: "Workbook",
     table_name: str,
-    key_column: str = "Key",
-    value_column: str = "Value",
+    key_column: str = "Key",  # TODO: Make this required in the next major version.
+    value_column: str = "Value",  # TODO: Make this required in the next major version.
+    ci: (
+        bool | Literal["warn"]
+    ) = False,  # TODO: Make this required in the next major version.
 ) -> Dict[str, Any]:
+    """
+    Read a two-column table from a workbook and return it as a dictionary.
+
+    Args:
+        book: The openpyxl workbook object from which to read the table.
+        table_name: The name of the table (ListObject or named range) to read.
+        key_column: The name of the column whose values to use as dictionary keys.
+        value_column: The name of the column whose values to use as dictionary values.
+        ci:
+            Whether the table name lookup should be case-insensitive.
+            When this is "warn", a warning is logged when the provided case does not match the actual case.
+
+    Returns:
+        A dictionary that maps each value from `key_column` in the specified table
+        to the corresponding value from `value_column`.
+    """
     data = read_table(
-        book=book, table_name=table_name, columns=[key_column, value_column]
+        book=book,
+        table_name=table_name,
+        columns=[key_column, value_column],
+        ci=ci,
     )
     return {row[key_column]: row[value_column] for row in data}
 

--- a/aa_py_openpyxl_util/_find_table.py
+++ b/aa_py_openpyxl_util/_find_table.py
@@ -1,4 +1,7 @@
-from typing import Tuple, TYPE_CHECKING
+from logging import getLogger
+from typing import Tuple, TYPE_CHECKING, Literal
+
+from pydicti import dicti
 
 if TYPE_CHECKING:
     from openpyxl import Workbook
@@ -7,16 +10,36 @@ if TYPE_CHECKING:
     from openpyxl.worksheet.worksheet import Worksheet
 
 
-def find_table(*, book: "Workbook", name: str) -> Tuple["Worksheet", str]:
+logger = getLogger(__name__)
+
+
+def find_table(
+    *,
+    book: "Workbook",
+    name: str,
+    ci: (
+        bool | Literal["warn"]
+    ) = False,  # TODO: Make this required in the next major version.
+) -> Tuple["Worksheet", str]:
     """
     Find a table in the given workbook. The table can be a named range or a ListObject.
+
+    Args:
+        book: The workbook to search through.
+        name: The name of the table (named range or ListObject).
+        ci:
+            Whether the table name lookup should be case-insensitive.
+            When this is "warn", a warning is logged when the provided case does not match the actual case.
+
+    Returns:
+        A tuple of (sheet, range).
     """
     try:
-        sheet, table_range = find_named_range_by_name(book=book, name=name)
+        sheet, table_range = find_named_range_by_name(book=book, name=name, ci=ci)
         table_type = "Named range"
     except KeyError as e1:
         try:
-            sheet, table = find_list_object_by_name(book=book, name=name)
+            sheet, table = find_list_object_by_name(book=book, name=name, ci=ci)
             table_range = table.ref
             table_type = "ListObject"
         except KeyError as e2:
@@ -36,21 +59,38 @@ def find_table(*, book: "Workbook", name: str) -> Tuple["Worksheet", str]:
     return sheet, table_range
 
 
-def find_named_range_by_name(*, book: "Workbook", name: str) -> Tuple["Worksheet", str]:
+def find_named_range_by_name(
+    *,
+    book: "Workbook",
+    name: str,
+    ci: bool | Literal["warn"],
+) -> Tuple["Worksheet", str]:
     """
     Find a named range by name.
 
     Args:
         book: The book to search through.
-        name: The name of the ListObject.
+        name: The name of the named range.
+        ci:
+            Whether the table name lookup should be case-insensitive.
+            When this is "warn", a warning is logged when the provided case does not match the actual case.
 
     Returns:
         A tuple of (sheet, range).
     """
+    book_defined_names = dicti(book.defined_names) if ci else book.defined_names
     try:
-        defined_name: "DefinedName" = book.defined_names[name]
+        defined_name: "DefinedName" = book_defined_names[name]
     except KeyError as e:
         raise KeyError(f"Named range `{name}` not found.") from e
+
+    if ci == "warn":
+        # Check for case mismatch
+        original_name = dicti((k, k) for k in book.defined_names.keys())[name]
+        if original_name != name:
+            logger.warning(
+                f"Table with exact name `{name}` not found. Using case-insensitive match `{original_name}` instead."
+            )
 
     try:
         destinations = list(defined_name.destinations)
@@ -65,7 +105,10 @@ def find_named_range_by_name(*, book: "Workbook", name: str) -> Tuple["Worksheet
 
 
 def find_list_object_by_name(
-    *, book: "Workbook", name: str
+    *,
+    book: "Workbook",
+    name: str,
+    ci: bool | Literal["warn"],
 ) -> Tuple["Worksheet", "Table"]:
     """
     Find a list object by name.
@@ -73,13 +116,25 @@ def find_list_object_by_name(
     Args:
         book: The book to search through.
         name: The name of the ListObject.
+        ci:
+            Whether the table name lookup should be case-insensitive.
+            When this is "warn", a warning is logged when the provided case does not match the actual case.
 
     Returns:
-        A tuple of (sheet, range).
+        A tuple of (sheet, table).
     """
     sheet: "Worksheet"
     for sheet in book.worksheets:
-        if name in sheet.tables:
-            return sheet, sheet.tables[name]
+        sheet_tables = dicti(sheet.tables) if ci else sheet.tables
+        if name in sheet_tables:
+            if ci == "warn":
+                # Check for case mismatch
+                original_name = dicti((k, k) for k in sheet.tables.keys())[name]
+                if original_name != name:
+                    logger.warning(
+                        f"Table with exact name `{name}` not found. Using case-insensitive match `{original_name}` instead."
+                    )
+
+            return sheet, sheet_tables[name]
 
     raise KeyError(f"ListObject `{name}` not found.")

--- a/test/test_find_table.py
+++ b/test/test_find_table.py
@@ -1,4 +1,5 @@
 import unittest
+from logging import WARNING
 
 from locate import this_dir
 
@@ -17,19 +18,71 @@ data_dir = this_dir().parent.joinpath("test_data")
 
 
 class TestFindTable(unittest.TestCase):
-    def test_tables(self) -> None:
+    def test_tables__case_sensitive(self) -> None:
         with safe_load_workbook(
             path=data_dir.joinpath("tables.xlsx"),
             read_only=False,
             data_only=False,
         ) as book:
-            sheet, table_range = find_table(book=book, name="Table1")
+            sheet, table_range = find_table(book=book, name="Table1", ci=False)
             self.assertEqual("Sheet1", sheet.title)
             self.assertEqual("$B$2:$C$4", table_range)
 
-            sheet, table_range = find_table(book=book, name="Table2")
+            for name in ["table1", "TABLE1"]:
+                with self.assertRaises(KeyError):
+                    find_table(book=book, name=name, ci=False)
+
+            sheet, table_range = find_table(book=book, name="Table2", ci=False)
             self.assertEqual("Sheet1", sheet.title)
             self.assertEqual("E2:F3", table_range)
+
+            for name in ["table2", "TABLE2"]:
+                with self.assertRaises(KeyError):
+                    find_table(book=book, name=name, ci=False)
+
+    def test_tables__case_insensitive(self) -> None:
+        with self.assertNoLogs(level=WARNING):
+            with safe_load_workbook(
+                path=data_dir.joinpath("tables.xlsx"),
+                read_only=False,
+                data_only=False,
+            ) as book:
+                for name in ["Table1", "table1", "TABLE1"]:
+                    sheet, table_range = find_table(book=book, name=name, ci=True)
+                    self.assertEqual("Sheet1", sheet.title)
+                    self.assertEqual("$B$2:$C$4", table_range)
+
+                for name in ["Table2", "table2", "TABLE2"]:
+                    sheet, table_range = find_table(book=book, name=name, ci=True)
+                    self.assertEqual("Sheet1", sheet.title)
+                    self.assertEqual("E2:F3", table_range)
+
+    def test_tables__case_insensitive_warn(self) -> None:
+        with self.assertLogs(level=WARNING) as logs:
+            with safe_load_workbook(
+                path=data_dir.joinpath("tables.xlsx"),
+                read_only=False,
+                data_only=False,
+            ) as book:
+                for name in ["Table1", "table1", "TABLE1"]:
+                    sheet, table_range = find_table(book=book, name=name, ci="warn")
+                    self.assertEqual("Sheet1", sheet.title)
+                    self.assertEqual("$B$2:$C$4", table_range)
+
+                for name in ["Table2", "table2", "TABLE2"]:
+                    sheet, table_range = find_table(book=book, name=name, ci="warn")
+                    self.assertEqual("Sheet1", sheet.title)
+                    self.assertEqual("E2:F3", table_range)
+
+        self.assertEqual(
+            [
+                "Table with exact name `table1` not found. Using case-insensitive match `Table1` instead.",
+                "Table with exact name `TABLE1` not found. Using case-insensitive match `Table1` instead.",
+                "Table with exact name `table2` not found. Using case-insensitive match `Table2` instead.",
+                "Table with exact name `TABLE2` not found. Using case-insensitive match `Table2` instead.",
+            ],
+            [r.message for r in logs.records],
+        )
 
     def test_not_tables(self) -> None:
         with safe_load_workbook(
@@ -39,27 +92,70 @@ class TestFindTable(unittest.TestCase):
         ) as book:
             # Does not exist
             with self.assertRaises(KeyError):
-                find_table(book=book, name="Table999")
+                find_table(book=book, name="Table999", ci=False)
 
             # Single cell is not a table
             with self.assertRaises(KeyError):
-                find_table(book=book, name="SingleCell1")
+                find_table(book=book, name="SingleCell1", ci=False)
 
             # Single row is not a table
             with self.assertRaises(KeyError):
-                find_table(book=book, name="SingleRow1")
+                find_table(book=book, name="SingleRow1", ci=False)
 
 
 class TestFindNamedRangeTable(unittest.TestCase):
-    def test_table1(self) -> None:
+
+    def test_case_sensitive(self) -> None:
         with safe_load_workbook(
             path=data_dir.joinpath("tables.xlsx"),
             read_only=False,
             data_only=False,
         ) as book:
-            sheet, table_range = find_named_range_by_name(book=book, name="Table1")
+            sheet, table_range = find_named_range_by_name(
+                book=book, name="Table1", ci=False
+            )
             self.assertEqual("Sheet1", sheet.title)
             self.assertEqual("$B$2:$C$4", table_range)
+
+            for name in ["table1", "TABLE1"]:
+                with self.assertRaises(KeyError):
+                    find_named_range_by_name(book=book, name=name, ci=False)
+
+    def test_case_insensitive(self) -> None:
+        with self.assertNoLogs(level=WARNING):
+            with safe_load_workbook(
+                path=data_dir.joinpath("tables.xlsx"),
+                read_only=False,
+                data_only=False,
+            ) as book:
+                for name in ["Table1", "table1", "TABLE1"]:
+                    sheet, table_range = find_named_range_by_name(
+                        book=book, name=name, ci=True
+                    )
+                    self.assertEqual("Sheet1", sheet.title)
+                    self.assertEqual("$B$2:$C$4", table_range)
+
+    def test_case_insensitive_warn(self) -> None:
+        with self.assertLogs(level=WARNING) as logs:
+            with safe_load_workbook(
+                path=data_dir.joinpath("tables.xlsx"),
+                read_only=False,
+                data_only=False,
+            ) as book:
+                for name in ["Table1", "table1", "TABLE1"]:
+                    sheet, table_range = find_named_range_by_name(
+                        book=book, name=name, ci="warn"
+                    )
+                    self.assertEqual("Sheet1", sheet.title)
+                    self.assertEqual("$B$2:$C$4", table_range)
+
+        self.assertEqual(
+            [
+                "Table with exact name `table1` not found. Using case-insensitive match `Table1` instead.",
+                "Table with exact name `TABLE1` not found. Using case-insensitive match `Table1` instead.",
+            ],
+            [r.message for r in logs.records],
+        )
 
     def test_single_cell(self) -> None:
         with safe_load_workbook(
@@ -67,7 +163,9 @@ class TestFindNamedRangeTable(unittest.TestCase):
             read_only=False,
             data_only=False,
         ) as book:
-            sheet, table_range = find_named_range_by_name(book=book, name="SingleCell1")
+            sheet, table_range = find_named_range_by_name(
+                book=book, name="SingleCell1", ci=False
+            )
             self.assertEqual("Sheet1", sheet.title)
             self.assertEqual("$H$2", table_range)
 
@@ -77,7 +175,9 @@ class TestFindNamedRangeTable(unittest.TestCase):
             read_only=False,
             data_only=False,
         ) as book:
-            sheet, table_range = find_named_range_by_name(book=book, name="SingleRow1")
+            sheet, table_range = find_named_range_by_name(
+                book=book, name="SingleRow1", ci=False
+            )
             self.assertEqual("Sheet1", sheet.title)
             self.assertEqual("$J$2:$L$2", table_range)
 
@@ -88,19 +188,59 @@ class TestFindNamedRangeTable(unittest.TestCase):
             data_only=False,
         ) as book:
             with self.assertRaises(KeyError):
-                find_named_range_by_name(book=book, name="Table999")
+                find_named_range_by_name(book=book, name="Table999", ci=False)
 
 
 class TestFindListObjectTable(unittest.TestCase):
-    def test_1(self) -> None:
+    def test_case_sensitive(self) -> None:
         with safe_load_workbook(
             path=data_dir.joinpath("tables.xlsx"),
             read_only=False,
             data_only=False,
         ) as book:
-            sheet, table = find_list_object_by_name(book=book, name="Table2")
+            sheet, table = find_list_object_by_name(book=book, name="Table2", ci=False)
             self.assertEqual("Sheet1", sheet.title)
             self.assertEqual("E2:F3", table.ref)
+
+            for name in ["table2", "TABLE2"]:
+                with self.assertRaises(KeyError):
+                    find_list_object_by_name(book=book, name=name, ci=False)
+
+    def test_case_insensitive(self) -> None:
+        with self.assertNoLogs(level=WARNING):
+            with safe_load_workbook(
+                path=data_dir.joinpath("tables.xlsx"),
+                read_only=False,
+                data_only=False,
+            ) as book:
+                for name in ["Table2", "table2", "TABLE2"]:
+                    sheet, table = find_list_object_by_name(
+                        book=book, name=name, ci=True
+                    )
+                    self.assertEqual("Sheet1", sheet.title)
+                    self.assertEqual("E2:F3", table.ref)
+
+    def test_case_insensitive_warn(self) -> None:
+        with self.assertLogs(level=WARNING) as logs:
+            with safe_load_workbook(
+                path=data_dir.joinpath("tables.xlsx"),
+                read_only=False,
+                data_only=False,
+            ) as book:
+                for name in ["Table2", "table2", "TABLE2"]:
+                    sheet, table = find_list_object_by_name(
+                        book=book, name=name, ci="warn"
+                    )
+                    self.assertEqual("Sheet1", sheet.title)
+                    self.assertEqual("E2:F3", table.ref)
+
+        self.assertEqual(
+            [
+                "Table with exact name `table2` not found. Using case-insensitive match `Table2` instead.",
+                "Table with exact name `TABLE2` not found. Using case-insensitive match `Table2` instead.",
+            ],
+            [r.message for r in logs.records],
+        )
 
     def test_not_found(self) -> None:
         with safe_load_workbook(
@@ -109,7 +249,7 @@ class TestFindListObjectTable(unittest.TestCase):
             data_only=False,
         ) as book:
             with self.assertRaises(KeyError):
-                find_list_object_by_name(book=book, name="Table999")
+                find_list_object_by_name(book=book, name="Table999", ci=False)
 
 
 if __name__ == "__main__":

--- a/test/write_only/test_write_tables_side_by_side.py
+++ b/test/write_only/test_write_tables_side_by_side.py
@@ -46,14 +46,14 @@ class TestWriteTablesSideBySide(unittest.TestCase):
             self.assertEqual([(2, 2), (2, 6)], [c for c, t in results.values()])
 
         def test(book: Workbook) -> None:
-            table1_sheet, table1_range = find_table(book=book, name="Table1")
+            table1_sheet, table1_range = find_table(book=book, name="Table1", ci=False)
             self.assertEqual("B2:D3", table1_range)
             self.assertEqual(
                 [["a", "b", "c"], [None, None, None]],
                 get_cell_values(table1_sheet[table1_range]),
             )
 
-            table2_sheet, table2_range = find_table(book=book, name="Table2")
+            table2_sheet, table2_range = find_table(book=book, name="Table2", ci=False)
             self.assertEqual("F2:G3", table2_range)
             self.assertEqual(
                 [["d", "e"], [None, None]],
@@ -94,14 +94,14 @@ class TestWriteTablesSideBySide(unittest.TestCase):
             self.assertEqual([(2, 2), (2, 6)], [c for c, t in results.values()])
 
         def test(book: Workbook) -> None:
-            table1_sheet, table1_range = find_table(book=book, name="Table1")
+            table1_sheet, table1_range = find_table(book=book, name="Table1", ci=False)
             self.assertEqual("B2:D4", table1_range)
             self.assertEqual(
                 [["a", "b", "c"], [1, 2, 3], [4, 5, 6]],
                 get_cell_values(table1_sheet[table1_range]),
             )
 
-            table2_sheet, table2_range = find_table(book=book, name="Table2")
+            table2_sheet, table2_range = find_table(book=book, name="Table2", ci=False)
             self.assertEqual("F2:G4", table2_range)
             self.assertEqual(
                 [["d", "e"], [7, 8], [9, 0]],
@@ -148,21 +148,21 @@ class TestWriteTablesSideBySide(unittest.TestCase):
             self.assertEqual([(2, 2), (2, 6), (2, 9)], [c for c, t in results.values()])
 
         def test(book: Workbook) -> None:
-            table1_sheet, table1_range = find_table(book=book, name="Table1")
+            table1_sheet, table1_range = find_table(book=book, name="Table1", ci=False)
             self.assertEqual("B2:D5", table1_range)
             self.assertEqual(
                 [["a", "b", "c"], [1, 2, 3], [2, 3, 4], [3, 4, 5]],
                 get_cell_values(table1_sheet[table1_range]),
             )
 
-            table2_sheet, table2_range = find_table(book=book, name="Table2")
+            table2_sheet, table2_range = find_table(book=book, name="Table2", ci=False)
             self.assertEqual("F2:G3", table2_range)
             self.assertEqual(
                 [["d", "e"], [None, None]],
                 get_cell_values(table2_sheet[table2_range]),
             )
 
-            table3_sheet, table3_range = find_table(book=book, name="Table3")
+            table3_sheet, table3_range = find_table(book=book, name="Table3", ci=False)
             self.assertEqual("I2:J4", table3_range)
             self.assertEqual(
                 [["f", "g"], [7, 8], [9, 0]],
@@ -195,7 +195,7 @@ class TestWriteTablesSideBySide(unittest.TestCase):
             )
 
         def test(book: Workbook) -> None:
-            table1_sheet, table1_range = find_table(book=book, name="Table1")
+            table1_sheet, table1_range = find_table(book=book, name="Table1", ci=False)
             self.assertEqual("B4:D7", table1_range)
             self.assertEqual(
                 [["a", "b", "c"], [1, 2, 3], [2, 3, 4], [3, 4, 5]],
@@ -236,7 +236,7 @@ class TestWriteTablesSideBySide(unittest.TestCase):
             )
 
         def test(book: Workbook) -> None:
-            table1_sheet, table1_range = find_table(book=book, name="Table1")
+            table1_sheet, table1_range = find_table(book=book, name="Table1", ci=False)
             self.assertEqual("B3:D6", table1_range)
             self.assertEqual(
                 [["a", "b", "c"], [1, 2, 3], [2, 3, 4], [3, 4, 5]],
@@ -290,10 +290,10 @@ class TestWriteTablesSideBySide(unittest.TestCase):
             )
 
         def test(book: Workbook) -> None:
-            table1_sheet, table1_range = find_table(book=book, name="Table1")
+            table1_sheet, table1_range = find_table(book=book, name="Table1", ci=False)
             self.assertEqual("B3:B6", table1_range)
 
-            table2_sheet, table2_range = find_table(book=book, name="Table2")
+            table2_sheet, table2_range = find_table(book=book, name="Table2", ci=False)
             self.assertEqual("E3:E6", table2_range)
 
         test_helper(write, test, True)
@@ -340,10 +340,10 @@ class TestWriteTablesSideBySide(unittest.TestCase):
             )
 
         def test(book: Workbook) -> None:
-            table1_sheet, table1_range = find_table(book=book, name="Table1")
+            table1_sheet, table1_range = find_table(book=book, name="Table1", ci=False)
             self.assertEqual("B3:C6", table1_range)
 
-            table2_sheet, table2_range = find_table(book=book, name="Table2")
+            table2_sheet, table2_range = find_table(book=book, name="Table2", ci=False)
             self.assertEqual("E3:F6", table2_range)
 
         test_helper(write, test, True)
@@ -383,7 +383,7 @@ class TestWriteTablesSideBySide(unittest.TestCase):
             )
 
         def test(book: Workbook) -> None:
-            table_sheet, table_range = find_table(book=book, name="Table1")
+            table_sheet, table_range = find_table(book=book, name="Table1", ci=False)
             self.assertEqual(
                 [["a", "b", "c"], [1, 2, 4], [2, 4, 8], [3, 6, 12], [4, 8, 16]],
                 get_cell_values(table_sheet[table_range]),
@@ -458,7 +458,7 @@ class TestWriteTablesSideBySide(unittest.TestCase):
             )
 
         def test(book: Workbook) -> None:
-            table_sheet, table_range = find_table(book=book, name="Table1")
+            table_sheet, table_range = find_table(book=book, name="Table1", ci=False)
             self.assertEqual(
                 [
                     ["a", "b", "c"],
@@ -526,7 +526,7 @@ class TestWriteTablesSideBySide(unittest.TestCase):
             )
 
         def test(book: Workbook) -> None:
-            table_sheet, table_range = find_table(book=book, name="Table1")
+            table_sheet, table_range = find_table(book=book, name="Table1", ci=False)
             self.assertEqual(
                 [["a"], [5], [5], [5], [5], [datetime(1900, 1, 5, 0, 0)]],
                 get_cell_values(table_sheet[table_range]),
@@ -604,13 +604,13 @@ class TestWriteTablesSideBySideOverMultipleSheets(unittest.TestCase):
             )
 
         def test(book: Workbook) -> None:
-            table1_sheet, table1_range = find_table(book=book, name="Table1")
+            table1_sheet, table1_range = find_table(book=book, name="Table1", ci=False)
             self.assertEqual(
                 [["a", "b"], [1, 2]], get_cell_values(table1_sheet[table1_range])
             )
             self.assertEqual("Tables", table1_sheet.title)
 
-            table2_sheet, table2_range = find_table(book=book, name="Table2")
+            table2_sheet, table2_range = find_table(book=book, name="Table2", ci=False)
             self.assertEqual(
                 [["a", "b"], [1, 2]], get_cell_values(table2_sheet[table2_range])
             )
@@ -643,13 +643,13 @@ class TestWriteTablesSideBySideOverMultipleSheets(unittest.TestCase):
             )
 
         def test(book: Workbook) -> None:
-            table1_sheet, table1_range = find_table(book=book, name="Table1")
+            table1_sheet, table1_range = find_table(book=book, name="Table1", ci=False)
             self.assertEqual(
                 [["a", "b"], [1, 2]], get_cell_values(table1_sheet[table1_range])
             )
             self.assertEqual("Tables", table1_sheet.title)
 
-            table2_sheet, table2_range = find_table(book=book, name="Table2")
+            table2_sheet, table2_range = find_table(book=book, name="Table2", ci=False)
             self.assertEqual(
                 [["a", "b"], [1, 2]], get_cell_values(table2_sheet[table2_range])
             )


### PR DESCRIPTION
To prevent breaking changes, the new argument defaults to `False` until the next major version, where it will become a required argument.